### PR TITLE
Update Tpetra_TestingUtilities.hpp

### DIFF
--- a/validation_tests/trilinos-tpetra/Tpetra_TestingUtilities.hpp
+++ b/validation_tests/trilinos-tpetra/Tpetra_TestingUtilities.hpp
@@ -53,7 +53,7 @@
 
 #include "Teuchos_UnitTestHarness.hpp"
 #include "Teuchos_ArrayRCP.hpp"
-#include "Kokkos_View.hpp"
+#include "Kokkos_Core.hpp"
 #include "KokkosCompat_View.hpp"
 #include "Tpetra_Core.hpp"
 #include "TpetraCore_ETIHelperMacros.h"


### PR DESCRIPTION
Updating a #include for a non-public Kokkos header file.

This was suggested by @crtrott. Needs to run through CI to ensure this fixes the issue we saw.